### PR TITLE
migrate the document links to docs.github.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![test](https://github.com/shogo82148/actions-upload-release-asset/workflows/test/badge.svg)
 
-This GitHub Action uploads release assets using [Upload a release asset](https://developer.github.com/v3/repos/releases/#upload-a-release-asset).
+This GitHub Action uploads release assets using [Upload a release asset](https://docs.github.com/en/rest/reference/repos#upload-a-release-asset).
 
 ## FEATURE
 
@@ -13,7 +13,7 @@ This GitHub Action uploads release assets using [Upload a release asset](https:/
 
 ### Upload assets when a release has been created
 
-You can upload assets when [a release has been created](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#release-event-release).
+You can upload assets when [a release has been created](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release).
 
 ```yaml
 on:


### PR DESCRIPTION
the documents are unified in docs.github.com
ref. https://github.blog/2020-07-01-launching-docs-github-com/