### PR TITLE
bump Node.js v16

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,7 +9,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "16.x"
           cache: 'npm'
       - run: npm ci
       - uses: reviewdog/action-eslint@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,10 @@ jobs:
       - name: disable auto CRLF
         run: git config --global core.autoCRLF false
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          cache: 'npm'
       - run: npm ci
       - run: npm run build
       - run: npm test
@@ -45,6 +49,10 @@ jobs:
       id: ${{ steps.create_release.outputs.id }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          cache: 'npm'
       - run: npm ci
       - run: npm run build
       - run: npm run pack

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ outputs:
   browser_download_url:
     description: 'The URL users can navigate to in order to download the uploaded asset'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'package'

--- a/src/upload-release-asset.ts
+++ b/src/upload-release-asset.ts
@@ -298,10 +298,10 @@ const regexUploadUrl = new RegExp(
 );
 export function parseUploadUrl(rawurl: string): Release {
   const match = rawurl.match(regexUploadUrl);
-  const groups = match?.groups;
-  if (!groups) {
+  if (!match || !match.groups) {
     throw new Error(`failed to parse the upload url: ${rawurl}`);
   }
+  const groups = match.groups;
   return {
     owner: groups["owner"],
     repo: groups["repo"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "es2021",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "outDir": "./lib",                        /* Redirect output structure to the directory. */
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
GitHub Actions Runner supports Node.js v16 LTS from version 2.285.0

- https://github.com/actions/runner/pull/1439

I'm waiting for official announce.