### PR TITLE
introduce grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# dependabot config
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
 version: 2
 updates:
   - package-ecosystem: npm
@@ -9,6 +12,11 @@ updates:
       # update too often, ignore patch releases
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-patch"]
+    groups:
+      jest-monorepo:
+        patterns:
+          - "jest"
+          - "jest-circus"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Grouped version updates for Dependabot public beta https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/