### PR TITLE
use the default test runner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,6 @@ updates:
       # update too often, ignore patch releases
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-patch"]
-    groups:
-      jest-monorepo:
-        patterns:
-          - "jest"
-          - "jest-circus"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,9 @@
 module.exports = {
   clearMocks: true,
-  moduleFileExtensions: ['js', 'ts'],
-  testEnvironment: 'node',
-  testMatch: ['**/*.test.ts'],
-  testRunner: 'jest-circus/runner',
+  moduleFileExtensions: ["js", "ts"],
+  testMatch: ["**/*.test.ts"],
   transform: {
-    '^.+\\.ts$': 'ts-jest'
+    "^.+\\.ts$": "ts-jest",
   },
-  verbose: true
-}
+  verbose: true,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "eslint-plugin-github": "^4.8.0",
         "eslint-plugin-jest": "^27.2.2",
         "jest": "^29.6.0",
-        "jest-circus": "^29.6.0",
         "js-yaml": "^4.1.0",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-github": "^4.8.0",
     "eslint-plugin-jest": "^27.2.2",
     "jest": "^29.6.0",
-    "jest-circus": "^29.6.0",
     "js-yaml": "^4.1.0",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.1",


### PR DESCRIPTION
jest-circus is now the default test runner.

https://www.npmjs.com/package/jest-circus

> Note: As of Jest 27, jest-circus is the default test runner, so you do not have to install it to use it.